### PR TITLE
read gl/GL.h and define constants

### DIFF
--- a/glxw_gen.py
+++ b/glxw_gen.py
@@ -94,6 +94,13 @@ int glxwInit%(upper_suffix)sCtx(struct glxw%(suffix)s *ctx);
 
         for include in api_includes:
             f.write('#include <%s>\n' % include)
+
+        for func in funcs:
+            f.write('#define %s __DO_NOT_USE_THIS_%s\n' % (func, func))
+        f.write('#include <GL/gl.h>\n')
+        for func in funcs:
+            f.write('#undef %s\n' % (func))
+
         f.write(common);
 
         f.write('\nstruct glxw%s {\n' % suffix)


### PR DESCRIPTION
Read <gl/GL.h> and get the constants defined there.

In this patch, declaration of OpenGL functions within gl/GL.h are renamed to
__DO_NOT_USE_THIS_\* by #define tricks and therefore will not conflict with
GLXW functions.
